### PR TITLE
Updated install_guithub commands to figure new syntax after getting e…

### DIFF
--- a/09_DevelopingDataProducts/slidify/index.Rmd
+++ b/09_DevelopingDataProducts/slidify/index.Rmd
@@ -42,8 +42,8 @@ library(devtools)
 - Second, install Slidify
 
 ```r
-install_github('slidify', 'ramnathv')
-install_github('slidifyLibraries', 'ramnathv')
+install_github('ramnathv/slidify')
+install_github('ramnathv/slidifyLibraries')
 ```
 
 - Third, load Slidify


### PR DESCRIPTION
…rror messages

Change prompted by getting this error message

> install_github("slidifyLibraries","ramnathv")
Downloading github repo ramnathv/slidifyLibraries@master
Error in curl::curl_fetch_memory(url, handle = handle) : 
  Timeout was reached
In addition: Warning message:
Username parameter is deprecated. Please use ramnathv/slidifyLibraries 

Fixed by doing the following 

> install_github("ramnathv/slidifyLibraries")
> install_github("ramnathv/slidify")

as per the diffs.